### PR TITLE
Update RNZeroconf.m

### DIFF
--- a/ios/RNZeroconf/RNZeroconf.m
+++ b/ios/RNZeroconf/RNZeroconf.m
@@ -33,6 +33,11 @@ RCT_EXPORT_METHOD(stop)
     [self.resolvingServices removeAllObjects];
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 #pragma mark - NSNetServiceBrowserDelegate
 
 // When a service is discovered.


### PR DESCRIPTION
As RN will change the behaviour: ```In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of. RN Zeroconf requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`.```