### PR TITLE
Acquire multicast lock before starting scan. This is required by Andr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ You can look at [the wiki](https://github.com/Apercu/react-native-zeroconf/wiki)
 
 TXT records will be available on iOS and Android >= 7.
 
+For Android please ensure your manifest is requesting all necessary permissions.
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+<uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+```
+
 ### Example
 
 Take a look at the [example folder](./example). Install the dependencies, run `node server.js` and launch the project.

--- a/android/src/main/java/com/balthazargronon/RCTZeroconf/ZeroconfModule.java
+++ b/android/src/main/java/com/balthazargronon/RCTZeroconf/ZeroconfModule.java
@@ -62,7 +62,7 @@ public class ZeroconfModule extends ReactContextBaseJavaModule {
 
         this.stop();
 
-        if(multicastLock == null) {
+        if (multicastLock == null) {
             WifiManager wifi = (WifiManager) getReactApplicationContext().getSystemService(Context.WIFI_SERVICE);
             multicastLock = wifi.createMulticastLock("multicastLock");
             multicastLock.setReferenceCounted(true);
@@ -118,7 +118,7 @@ public class ZeroconfModule extends ReactContextBaseJavaModule {
         if (mDiscoveryListener != null) {
             mNsdManager.stopServiceDiscovery(mDiscoveryListener);
         }
-        if(multicastLock != null) {
+        if (multicastLock != null) {
             multicastLock.release();
         }
         mDiscoveryListener = null;


### PR DESCRIPTION
…oid Pie. Release multicastlock on stop.

resolves #72.

We ran into an issue with zeroconf and NSD scan. Everything working well on Android 8, but on Android Pie it would return immediately with nothing found. This seems to be a limit on multicast traffic to save battery. Solution is to acquire the lock before scanning.

Also must ensure all permissions are requested. Specifically CHANGE_WIFI_MULTICAST_STATE.

    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />