### PR TITLE
Emit a proper error object when an error arises

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export default class Zeroconf extends EventEmitter {
 
     this._dListeners.start = DeviceEventEmitter.addListener('RNZeroconfStart', () => this.emit('start'))
     this._dListeners.stop = DeviceEventEmitter.addListener('RNZeroconfStop', () => this.emit('stop'))
-    this._dListeners.error = DeviceEventEmitter.addListener('RNZeroconfError', err => this.emit('error', err))
+    this._dListeners.error = DeviceEventEmitter.addListener('RNZeroconfError', err => this.emit('error', new Error(err))
 
     this._dListeners.found = DeviceEventEmitter.addListener('RNZeroconfFound', service => {
       if (!service || !service.name) { return }


### PR DESCRIPTION
This fixes an issue reported here: https://github.com/balthazar/react-native-zeroconf/issues/45