### PR TITLE
Add podspec

### DIFF
--- a/RNZeroconf.podspec
+++ b/RNZeroconf.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "RNZeroconf"
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/YannDub/react-native-zeroconf.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
Hi, since React Native v0.60, ios bundle use Cocoapod to load all React dependencies. Xcode seems to have some problems to compile react-native-zeroconf in a project because React is now installed with Podfile.

The solution is to add a "_.podspec file_" which is recognized by Cocoapod when the command `pod install` is executed.