### PR TITLE
Added TXT functionality for both Android & iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Allow you to clean the listeners, avoiding potential memory leaks ([#33](https:/
 
 If you cleaned the listeners and need to get them back on.
 
-###### `publishService(type, protocol, domain, name, port)` Publish a service
+###### `publishService(type, protocol, domain, name, port, txt)` Publish a service
 
 This adds a service for the current device to the discoverable services on the network.
 
@@ -65,6 +65,7 @@ This adds a service for the current device to the discoverable services on the n
 `type` should be both type and protocol, underscore prefixed, for example `'_http._tcp'`
 `name` should be unique to the device, often the device name
 `port` should be an integer
+`txt` should be a hash, for example `{"foo": "bar"}`
 
 ###### `unpublishService(name)` Unpublish a service
 

--- a/android/src/main/java/com/balthazargronon/RCTZeroconf/ZeroconfModule.java
+++ b/android/src/main/java/com/balthazargronon/RCTZeroconf/ZeroconfModule.java
@@ -15,6 +15,8 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import javax.annotation.Nullable;
@@ -145,7 +147,7 @@ public class ZeroconfModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void registerService(String type, String protocol, String domain, String name, int port) {
+    public void registerService(String type, String protocol, String domain, String name, int port, ReadableMap txt) {
         String serviceType = String.format("_%s._%s.", type, protocol);
 
         final NsdManager nsdManager = this.getNsdManager();
@@ -153,6 +155,12 @@ public class ZeroconfModule extends ReactContextBaseJavaModule {
         serviceInfo.setServiceName(name);
         serviceInfo.setServiceType(serviceType);
         serviceInfo.setPort(port);
+
+        ReadableMapKeySetIterator iterator = txt.keySetIterator();
+        while (iterator.hasNextKey()) {
+            String key = iterator.nextKey();
+            serviceInfo.setAttribute(key, txt.getString(key));
+        }
 
         nsdManager.registerService(
                 serviceInfo, NsdManager.PROTOCOL_DNS_SD, new ServiceRegistrationListener());

--- a/ios/RNZeroconf/RNZeroconf.m
+++ b/ios/RNZeroconf/RNZeroconf.m
@@ -48,11 +48,17 @@ RCT_EXPORT_METHOD(registerService:(NSString *)type
                   protocol:(NSString *)protocol
                   domain:(NSString *)domain
                   name:(NSString *)name
-                  port:(int)port)
+                  port:(int)port
+                  txt:(NSDictionary *)txt)
 {
     const NSNetService *svc = [[NSNetService alloc] initWithDomain:domain type:[NSString stringWithFormat:@"_%@._%@.", type, protocol] name:name port:port];
     [svc setDelegate:self];
     [svc scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+
+    if (txt) {
+      NSData *txtData = [NSNetService dataFromTXTRecordDictionary:txt];
+      [svc setTXTRecordData:txtData];
+    }
 
     [svc publish];
     self.publishedServices[svc.name] = svc;

--- a/src/index.js
+++ b/src/index.js
@@ -127,8 +127,8 @@ export default class Zeroconf extends EventEmitter {
   /**
    * Publish a service
    */
-  publishService(type, protocol, domain = 'local.', name, port) {
-    RNZeroconf.registerService(type, protocol, domain, name, port)
+  publishService(type, protocol, domain = 'local.', name, port, txt = {}) {
+    RNZeroconf.registerService(type, protocol, domain, name, port, txt)
   }
 
   /**


### PR DESCRIPTION
Hello

This PR implements the TXT record for both Android & iOS.

I've implemented the functionality for iOS and pulled in the changes from #99 as were implemented by @FrankFundel. I also added the missing bits as requested in that PR:

- default parameter for TXT argument (please double check this, if you're happy with this approach)
- updated the README documentation for `publishService`

But unlike in #99, I didn't touch `package.json`.

Please see what you make of this change and let me know if something else should be added.

Also thanks for the package @balthazar.