### PR TITLE
Convert all the values for TXT to strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,11 @@ export default class Zeroconf extends EventEmitter {
    * Publish a service
    */
   publishService(type, protocol, domain = 'local.', name, port, txt = {}) {
-    RNZeroconf.registerService(type, protocol, domain, name, port, txt)
+    if (Object.keys(txt).length !== 0) {
+      Object.entries(txt).map(([key, value]) => txt[key] = value.toString());
+    }
+
+    RNZeroconf.registerService(type, protocol, domain, name, port, txt);
   }
 
   /**


### PR DESCRIPTION
As mentioned in https://github.com/balthazar/react-native-zeroconf/issues/124#issuecomment-617085761

Adds the ability to handle the values other than strings for
TXT. Previously any other values, like integer, boolean would be ignored.

On iOS, non string values would ensure that the TXT value would not be set at all, even if any other key/value pairs contained strings.

On Android, it would throw an error if the values weren't strings.