### PR TITLE
fix bugs unhandled exception

### DIFF
--- a/ios/RNZeroconf/RNZeroconf.m
+++ b/ios/RNZeroconf/RNZeroconf.m
@@ -207,11 +207,7 @@ RCT_EXPORT_METHOD(unregisterService:(NSString *) serviceName)
 
 - (void) reportError:(NSDictionary *)errorDict
 {
-    for (int a = 0; a < errorDict.count; ++a) {
-        NSString *key = [[errorDict allKeys] objectAtIndex:a];
-        NSString *val = [errorDict objectForKey:key];
-        [self.bridge.eventDispatcher sendDeviceEventWithName:@"RNZeroconfError" body:val];
-    }
+    [self.bridge.eventDispatcher sendDeviceEventWithName:@"RNZeroconfError" body:[NSString stringWithFormat:@"%@",errorDict]];
 }
 
 @end

--- a/src/index.js
+++ b/src/index.js
@@ -35,9 +35,11 @@ export default class Zeroconf extends EventEmitter {
       this.emit('stop'),
     )
 
-    this._dListeners.error = DeviceEventEmitter.addListener('RNZeroconfError', err =>
-      this.emit('error', err),
-    )
+    this._dListeners.error = DeviceEventEmitter.addListener('RNZeroconfError', err =>{
+      if(this.listenerCount('error')>0){
+        this.emit('error', new Error(err))
+      }
+    })
 
     this._dListeners.found = DeviceEventEmitter.addListener('RNZeroconfFound', service => {
       if (!service || !service.name) {

--- a/src/index.js
+++ b/src/index.js
@@ -35,8 +35,8 @@ export default class Zeroconf extends EventEmitter {
       this.emit('stop'),
     )
 
-    this._dListeners.error = DeviceEventEmitter.addListener('RNZeroconfError', err =>{
-      if(this.listenerCount('error')>0){
+    this._dListeners.error = DeviceEventEmitter.addListener('RNZeroconfError', err => {
+      if (this.listenerCount('error') > 0) {
         this.emit('error', new Error(err))
       }
     })


### PR DESCRIPTION
this PR should fix [#45](https://github.com/balthazar/react-native-zeroconf/issues/45).
the cause of [#45](https://github.com/balthazar/react-native-zeroconf/issues/45) are
1. the [EventEmitor will throw an exception when an error needs to emit but without even an error listener was hooked] (https://nodejs.org/api/events.html#events_error_events)
2. if we create two or more Zeroconf instances, then there are multiple subscriptions to DeviceEventEmitter.addListener('RNZeroconfError').if anyone of them isn't listening 'error', the exception will throw. but usually, the multiple instances will act as different roles, for example, one for service publisher, another for service scanner. so it is unnecessary to force them both to hook the error listener up.    

This fix just is a quick and dirty change. but it works. so wouldn't change the current interface.
For a better solution, it is had better to make the Zeroconf as a singleton too(will break the interface compatibility) or design a complex event dispatch to support multiple instances of Zeroconf.

Moreover, the errorDict is to represent one error. so fix it on the native side.