### PR TITLE
raise react-native version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "events": "^3.0.0"
   },
   "peerDependencies": {
-    "react-native": ">=0.60 <0.64"
+    "react-native": ">=0.60 <0.65"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "events": "^3.0.0"
   },
   "peerDependencies": {
-    "react-native": ">=0.60 <0.65"
+    "react-native": ">=0.60"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
after creating empty react-native project and trying to install react-native-zeroconf you can get this error:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: testreactnativeapp@0.0.1
npm ERR! Found: react-native@0.64.2
npm ERR! node_modules/react-native
npm ERR!   react-native@"0.64.2" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react-native@">=0.60 <0.64" from react-native-zeroconf@0.13.2
npm ERR! node_modules/react-native-zeroconf
npm ERR!   react-native-zeroconf@"*" from the root project
```

after raising react-native version everything works fine