### PR TITLE
Android: resolve services with multiple IPv4 and IPv6 addresses

### DIFF
--- a/android/src/main/java/com/balthazargronon/RCTZeroconf/rx2dnssd/DnssdImpl.java
+++ b/android/src/main/java/com/balthazargronon/RCTZeroconf/rx2dnssd/DnssdImpl.java
@@ -87,20 +87,16 @@ public class DnssdImpl implements Zeroconf {
         service.putString(ZeroconfModule.KEY_SERVICE_NAME, serviceInfo.getServiceName());
         final List<InetAddress> hostList = serviceInfo.getInetAddresses();
         final String fullServiceName;
-        if (hostList == null) {
-            fullServiceName = serviceInfo.getServiceName();
-        } else {
-            Log.d("TAG", serviceInfo.getServiceName());
-            fullServiceName = serviceInfo.getServiceName();
-            service.putString(ZeroconfModule.KEY_SERVICE_HOST, fullServiceName);
+        Log.d("TAG", serviceInfo.getServiceName());
+        fullServiceName = serviceInfo.getServiceName();
+        service.putString(ZeroconfModule.KEY_SERVICE_HOST, fullServiceName);
 
-            WritableArray addresses = new WritableNativeArray();
-            for (InetAddress host : hostList) {
-				addresses.pushString(host.getHostAddress());					
-			}
-
-            service.putArray(ZeroconfModule.KEY_SERVICE_ADDRESSES, addresses);
+        WritableArray addresses = new WritableNativeArray();
+        for (InetAddress host : hostList) {
+            addresses.pushString(host.getHostAddress());
         }
+
+        service.putArray(ZeroconfModule.KEY_SERVICE_ADDRESSES, addresses);
         service.putString(ZeroconfModule.KEY_SERVICE_FULL_NAME, fullServiceName);
         service.putInt(ZeroconfModule.KEY_SERVICE_PORT, serviceInfo.getPort());
 


### PR DESCRIPTION
Hi,
I noticed that when using DNSSD mode on Android, services always resolve with a single IP address which might be not enough sometimes. After a brief investigation (I am no Java expert) I saw that in android/src/main/java/com/balthazargronon/RCTZeroconf/rx2dnssd/DnssdImpl.java file the IP addresses are retrieved with the help of a deprecated getInet4Address method (line 87). Replacing it with by getInetAddresses allows to get multiple addresses — IPv4 as well as IPv6. At least that what happens when running the app on iOS.