### PR TITLE
Added support for React Native for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Get running services advertizing themselves using Zeroconf implementations like 
     react-native link
     # for ios (when using CocoaPods): 
     (cd ios && pod install)
+    # for macOS (when using CocoaPods):
+    (cd macos && pod install)
 
 You can look at [the wiki](https://github.com/Apercu/react-native-zeroconf/wiki) if you prefer a manual install.
 

--- a/react-native-zeroconf.podspec
+++ b/react-native-zeroconf.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package['author']
   s.homepage     = package['homepage']
   s.ios.deployment_target = '9.0'
+  s.macos.deployment_target = '10.13'
   s.tvos.deployment_target = '9.0'
   
   s.source       = { :git => "https://github.com/balthazar/react-native-zeroconf.git", :tag => "v#{s.version}" }


### PR DESCRIPTION
Thank you for reviewing this pr. This pr includes support to use this library with React Native for macOS 10.13. It appears we only need to add the development target. Install instructions are also included