### PR TITLE
added addresses dictionary with keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Get running services advertizing themselves using Zeroconf implementations like 
     react-native link
     # for ios (when using CocoaPods): 
     (cd ios && pod install)
+    # for macOS (when using CocoaPods):
+    (cd macos && pod install)
 
 You can look at [the wiki](https://github.com/Apercu/react-native-zeroconf/wiki) if you prefer a manual install.
 

--- a/ios/RNZeroconf/RNNetServiceSerializer.h
+++ b/ios/RNZeroconf/RNNetServiceSerializer.h
@@ -11,6 +11,7 @@
 FOUNDATION_EXPORT const NSString *kRNServiceKeysName;
 FOUNDATION_EXPORT const NSString *kRNServiceKeysFullName;
 FOUNDATION_EXPORT const NSString *kRNServiceKeysAddresses;
+FOUNDATION_EXPORT const NSString *kRNServiceKeysAddressesDict;
 FOUNDATION_EXPORT const NSString *kRNServiceKeysHost;
 FOUNDATION_EXPORT const NSString *kRNServiceKeysPort;
 FOUNDATION_EXPORT const NSString *kRNServiceTxtRecords;

--- a/ios/RNZeroconf/RNNetServiceSerializer.m
+++ b/ios/RNZeroconf/RNNetServiceSerializer.m
@@ -12,6 +12,7 @@
 const NSString *kRNServiceKeysName = @"name";
 const NSString *kRNServiceKeysFullName = @"fullName";
 const NSString *kRNServiceKeysAddresses = @"addresses";
+const NSString *kRNServiceKeysAddressesDict = @"addressesDict";
 const NSString *kRNServiceKeysHost = @"host";
 const NSString *kRNServiceKeysPort = @"port";
 const NSString *kRNServiceTxtRecords = @"txt";
@@ -27,6 +28,7 @@ const NSString *kRNServiceTxtRecords = @"txt";
     if (resolved) {
         serviceInfo[kRNServiceKeysFullName] = [NSString stringWithFormat:@"%@%@", service.hostName, service.type];
         serviceInfo[kRNServiceKeysAddresses] = [self addressesFromService:service];
+        serviceInfo[kRNServiceKeysAddressesDict] = [self addressesDictFromService:service];
         serviceInfo[kRNServiceKeysHost] = service.hostName;
         serviceInfo[kRNServiceKeysPort] = @(service.port);
         
@@ -83,6 +85,42 @@ const NSString *kRNServiceTxtRecords = @"txt";
     }
 
     return [NSArray arrayWithArray:addresses];
+}
+
++ (NSDictionary<NSString *, NSString *> *) addressesDictFromService:(NSNetService *)service
+{
+    NSMutableDictionary<NSString *, NSString *> *addressesDict = [NSMutableDictionary dictionary];
+
+    // source: http://stackoverflow.com/a/4976808/2715
+    char addressBuffer[INET6_ADDRSTRLEN];
+
+    for (NSData *data in service.addresses) {
+        memset(addressBuffer, 0, INET6_ADDRSTRLEN);
+
+        typedef union {
+            struct sockaddr sa;
+            struct sockaddr_in ipv4;
+            struct sockaddr_in6 ipv6;
+        } ip_socket_address;
+
+        ip_socket_address *socketAddress = (ip_socket_address *)[data bytes];
+
+        if (socketAddress && (socketAddress->sa.sa_family == AF_INET || socketAddress->sa.sa_family == AF_INET6)) {
+            const char *addressStr = inet_ntop(
+                socketAddress->sa.sa_family,
+                (socketAddress->sa.sa_family == AF_INET ? (void *)&(socketAddress->ipv4.sin_addr) : (void *)&(socketAddress->ipv6.sin6_addr)),
+                addressBuffer,
+                sizeof(addressBuffer)
+            );
+
+            if (addressStr) {
+                NSString *key = socketAddress->sa.sa_family == AF_INET ? @"IPv4" : @"IPv6";
+                addressesDict[key] = [NSString stringWithUTF8String:addressStr];
+            }
+        }
+    }
+
+    return [addressesDict copy];
 }
 
 @end

--- a/react-native-zeroconf.podspec
+++ b/react-native-zeroconf.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package['author']
   s.homepage     = package['homepage']
   s.ios.deployment_target = '9.0'
+  s.macos.deployment_target = '10.13'
   s.tvos.deployment_target = '9.0'
   
   s.source       = { :git => "https://github.com/balthazar/react-native-zeroconf.git", :tag => "v#{s.version}" }


### PR DESCRIPTION
Added addresses dictionary with keys.

returns the follow 
````
"port": 52968,
  "addresses": [
    "127.0.0.1",
    "::1",
    "re20::1",
    "192.168.1.10",
    "fe82::fh9c:4a3R:fed2:79e1",
  ],
  "fullName": "the real full name._tcp.",
  "host": "the real local name.local.",
  "addressesDict": {
    "IPv4": "192.168.1.10",
    "IPv6": "fe82::fh9c:4a3R:fed2:79e1",
  },
  "txt": {},
  "name": "service name"
}
````

Would be nice if we could figure how to add Mac address and local address with keys to the addressesDict