### PR TITLE
Prevent crash in onCatalystInstanceDestroy

### DIFF
--- a/android/src/main/java/com/balthazargronon/RCTZeroconf/ZeroconfModule.java
+++ b/android/src/main/java/com/balthazargronon/RCTZeroconf/ZeroconfModule.java
@@ -106,7 +106,7 @@ public class ZeroconfModule extends ReactContextBaseJavaModule {
         try {
             stop(ZeroConfImplFactory.NSD_IMPL);
             stop(ZeroConfImplFactory.DNSSD_IMPL);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             Log.e(getClass().getName(), e.getMessage(), e);
             sendEvent(getReactApplicationContext(), ZeroconfModule.EVENT_ERROR, "Exception During Catalyst Destroy: " + e.getMessage());
         }


### PR DESCRIPTION
As described in #173, a uncaught exception related to `DNSSD` might happen here.