### PR TITLE
feat: throw error if local network permissions are not enabled

### DIFF
--- a/android/src/main/java/com/balthazargronon/RCTZeroconf/nsd/NsdServiceImpl.java
+++ b/android/src/main/java/com/balthazargronon/RCTZeroconf/nsd/NsdServiceImpl.java
@@ -6,6 +6,10 @@ import android.net.nsd.NsdManager;
 import android.net.nsd.NsdServiceInfo;
 import android.net.wifi.WifiManager;
 import android.os.Build;
+import android.Manifest;
+import android.content.pm.PackageManager;
+import androidx.core.content.ContextCompat;
+
 
 import com.balthazargronon.RCTZeroconf.Zeroconf;
 import com.balthazargronon.RCTZeroconf.ZeroconfModule;
@@ -45,6 +49,12 @@ public class NsdServiceImpl implements Zeroconf {
         }
 
         this.stop();
+
+        if (ContextCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.CHANGE_WIFI_MULTICAST_STATE) != PackageManager.PERMISSION_GRANTED) {
+            String error = "Local network permission is not granted. Please request the necessary permission.";
+            zeroconfModule.sendEvent(getReactApplicationContext(), ZeroconfModule.EVENT_ERROR, error);
+            return;
+        }
 
         if (multicastLock == null) {
             @SuppressLint("WifiManagerLeak") WifiManager wifi = (WifiManager) getReactApplicationContext().getSystemService(Context.WIFI_SERVICE);

--- a/ios/RNZeroconf/RNZeroconf.m
+++ b/ios/RNZeroconf/RNZeroconf.m
@@ -9,6 +9,9 @@
 #import "RNZeroconf.h"
 #import "RNNetServiceSerializer.h"
 
+#import <UIKit/UIKit.h>
+#import <CoreFoundation/CoreFoundation.h>
+
 @interface RNZeroconf ()
 
 @property (nonatomic, strong, readonly) NSMutableDictionary *resolvingServices;
@@ -25,6 +28,18 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(scan:(NSString *)type protocol:(NSString *)protocol domain:(NSString *)domain)
 {
     [self stop];
+
+    if (@available(iOS 14.0, *)) {
+        if (CLLocationManager.locationServicesEnabled) {
+            CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
+            if (status != kCLAuthorizationStatusAuthorizedAlways && status != kCLAuthorizationStatusAuthorizedWhenInUse) {
+                NSString *error = @"Local network permission is not granted. Please request the necessary permission.";
+                [self reportError:@{@"message": error}];
+                return;
+            }
+        } 
+    }
+
     [self.browser searchForServicesOfType:[NSString stringWithFormat:@"_%@._%@.", type, protocol] inDomain:domain];
 }
 


### PR DESCRIPTION
A fix to address #177
Have modified [NsdServiceImpl.java](https://github.com/sudharsangs/react-native-zeroconf/commit/6131483ba16c64d7991f13c2eef696a008934f00#diff-1bc1f5a9e7fe86eeb7abf50bb6dece85f7dbcae4ff6223ac9df27dbfad212697) and [RNZeroconf.m](https://github.com/sudharsangs/react-native-zeroconf/commit/6131483ba16c64d7991f13c2eef696a008934f00#diff-f6134b3598ec57d2409991415d979fd0119454619a9dbca56eb6414c77faf0ff) to throw errors if local network permissions are not given 